### PR TITLE
Add javafx dependencies to implementation dependency configuration

### DIFF
--- a/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
@@ -61,7 +61,7 @@ public class JavaFXPlugin implements Plugin<Project> {
                     .collect(Collectors.toSet());
 
             javaFXModules.forEach(javaFXModule -> {
-                project.getDependencies().add("compile",
+                project.getDependencies().add("implementation",
                         String.format("org.openjfx:%s:%s:%s", javaFXModule.getArtifactName(), javaFXOptions.getVersion(), platform));
             });
         });


### PR DESCRIPTION
JavaFX dependencies are added to the `implementation` dependency configuration instead of the deprecated `compile`.

Fixes issue #13.