### PR TITLE
Allow Gradle multi-projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'org.openjfx'
-version '0.0.5'
+version '0.0.6-SNAPSHOT'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/src/main/java/org/openjfx/gradle/JavaFXOptions.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXOptions.java
@@ -1,18 +1,35 @@
 package org.openjfx.gradle;
 
+import com.google.gradle.osdetector.OsDetector;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Optional;
+import java.util.TreeSet;
 
 public class JavaFXOptions {
 
     private String version = "11.0.1";
-    private List<String> modules = new ArrayList<>();
+    private final List<String> modules = new ArrayList<>();
+    private final Project project;
+    private String platform;
 
     public JavaFXOptions(Project project) {
+	this.project = project;
+        detectPlatform(project);
+    }
+
+    private void detectPlatform(Project project) {
+        String os = project.getExtensions().getByType(OsDetector.class).getOs();
+        platform = os;
+        if ("osx".equals(os)) {
+            platform = "mac";
+        } else if ("windows".equals(os)) {
+            platform = "win";
+        }
     }
 
     public String getVersion() {
@@ -28,11 +45,27 @@ public class JavaFXOptions {
     }
 
     public void setModules(List<String> modules) {
-        this.modules = modules;
+	this.modules.clear();
+        this.modules.addAll(modules);
+
+	validateModules();
+
+	var definedJavaFXModuleNames = new TreeSet<>(getModules());
+
+        var javaFXModules = definedJavaFXModuleNames.stream()
+                    .map(JavaFXModule::fromModuleName)
+                    .flatMap(Optional::stream)
+                    .flatMap(javaFXModule -> javaFXModule.getMavenDependencies().stream())
+                    .collect(Collectors.toSet());
+
+        javaFXModules.forEach(javaFXModule -> {
+                project.getDependencies().add("compile",
+                        String.format("org.openjfx:%s:%s:%s", javaFXModule.getArtifactName(), getVersion(), platform));
+	    });
     }
 
     public void modules(String...moduleNames) {
-        this.modules.addAll(List.of(moduleNames));
+        setModules(List.of(moduleNames));
     }
 
     public void validateModules() {

--- a/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
@@ -9,9 +9,7 @@ import org.gradle.api.tasks.JavaExec;
 import org.javamodularity.moduleplugin.ModuleSystemPlugin;
 import org.javamodularity.moduleplugin.tasks.ModuleOptions;
 
-import java.util.Optional;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 public class JavaFXPlugin implements Plugin<Project> {
 
@@ -40,7 +38,7 @@ public class JavaFXPlugin implements Plugin<Project> {
     }
 
     private void applyDependencies(Project project) {
-        project.afterEvaluate(c -> {
+	project.afterEvaluate(c -> {
             JavaFXOptions javaFXOptions = project.getExtensions().getByType(JavaFXOptions.class);
             javaFXOptions.validateModules();
 
@@ -54,16 +52,7 @@ public class JavaFXPlugin implements Plugin<Project> {
                 }
             }
 
-            var javaFXModules = definedJavaFXModuleNames.stream()
-                    .map(JavaFXModule::fromModuleName)
-                    .flatMap(Optional::stream)
-                    .flatMap(javaFXModule -> javaFXModule.getMavenDependencies().stream())
-                    .collect(Collectors.toSet());
-
-            javaFXModules.forEach(javaFXModule -> {
-                project.getDependencies().add("compile",
-                        String.format("org.openjfx:%s:%s:%s", javaFXModule.getArtifactName(), javaFXOptions.getVersion(), platform));
-            });
         });
+
     }
 }


### PR DESCRIPTION
Currently, this plugin modifies the project dependencies by pushing a closure to the project's `afterEvaluate` method. This fails in a Gradle multi-project setup, since Gradle does not allow the modification of a project's dependencies if another project already has consumed these.

Dependencies must be updated as the project is evaluated, not after. The `beforeEvaluate` method is not an alternative, since this method is not applicable for the root project.

To resolve this problem, I moved the project dependencies update from `afterEvaluate` to the `setModules` method which is called during project evaluation.

Cf. [https://discuss.gradle.org/t/when-can-a-plugin-change-a-projects-dependencies/17505](https://discuss.gradle.org/t/when-can-a-plugin-change-a-projects-dependencies/17505) and [https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html](https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html)