### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: java
 
+sudo: required
+
+dist: trusty
+
 install: true
 
 cache:
     directories:
         - $HOME/.m2
         - $HOME/.gradle
+
+before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3
 
 before_script:
     - ./gradlew --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+
+install: true
+
+cache:
+    directories:
+        - $HOME/.m2
+        - $HOME/.gradle
+
+before_script:
+    - ./gradlew --version
+
+script:
+    - TERM=dumb ./gradlew build --scan
+
+jdk:
+    - oraclejdk11

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
+    id 'com.gradle.build-scan' version '2.1'
     id 'java-gradle-plugin'
     id 'com.github.hierynomus.license' version '0.15.0'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'maven-publish'
-    id 'com.gradle.build-scan' version '2.1'
 }
 
 buildScan {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,12 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'maven-publish'
+    id 'com.gradle.build-scan' version '2.1'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 group 'org.openjfx'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

If this PR is accepted then scan generation must be enabled on the command line, like so

    ./gradlew build --scan