### PR TITLE
added gradle kotlin DSL code samples to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,13 @@ To use the plugin, apply the following two steps:
     buildscript {
         repositories {
             maven {
-                setUrl( "https://plugins.gradle.org/m2/")
+                setUrl("https://plugins.gradle.org/m2/")
             }
         }
         dependencies {
-            classpath( "org.openjfx:javafx-plugin:0.0.7")
+            classpath("org.openjfx:javafx-plugin:0.0.7")
         }
     }
-
     apply(plugin = "org.openjfx.javafxplugin")
 
 
@@ -67,6 +66,5 @@ Specify all the JavaFX modules that your project uses:
 **Kotlin**
 
     javafx {
-        modules.add("javafx.controls")
-        modules.add("javafx.fxml")
+        modules = listOf("javafx.controls", "javafx.fxml")
     }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ To use the plugin, apply the following two steps:
             classpath 'org.openjfx:javafx-plugin:0.0.7'
         }
     }
-    
     apply plugin: 'org.openjfx.javafxplugin'
 
 **Kotlin**

--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ Specify all the JavaFX modules that your project uses:
 **Kotlin**
 
     javafx {
-        modules = listOf("javafx.controls", "javafx.fxml")
+        modules("javafx.controls", "javafx.fxml")
     }

--- a/README.md
+++ b/README.md
@@ -8,13 +8,23 @@ To use the plugin, apply the following two steps:
 
 ### 1. Apply the plugin
 
-Using the `plugins` DSL:
+##### Using the `plugins` DSL:
+
+**Groovy**
 
     plugins {
         id 'org.openjfx.javafxplugin' version '0.0.7'
     }
 
-Alternatively, you can use the `buildscript` DSL:
+**Kotlin**
+
+    plugins {
+        id("org.openjfx.javafxplugin") version "0.0.7"
+    }
+
+##### Alternatively, you can use the `buildscript` DSL:
+
+**Groovy**
 
     buildscript {
         repositories {
@@ -26,13 +36,38 @@ Alternatively, you can use the `buildscript` DSL:
             classpath 'org.openjfx:javafx-plugin:0.0.7'
         }
     }
-
+    
     apply plugin: 'org.openjfx.javafxplugin'
+
+**Kotlin**
+
+    buildscript {
+        repositories {
+            maven {
+                setUrl( "https://plugins.gradle.org/m2/")
+            }
+        }
+        dependencies {
+            classpath( "org.openjfx:javafx-plugin:0.0.7")
+        }
+    }
+
+    apply(plugin = "org.openjfx.javafxplugin")
+
 
 ### 2. Specify JavaFX modules
 
 Specify all the JavaFX modules that your project uses:
 
+**Groovy**
+
     javafx {
         modules = [ 'javafx.controls', 'javafx.fxml' ]
+    }
+
+**Kotlin**
+
+    javafx {
+        modules.add("javafx.controls")
+        modules.add("javafx.fxml")
     }


### PR DESCRIPTION
Since Gradle Kotlin DSL is becoming more common we should add related code samples to the readme.