### PR TITLE
Vm options for executable added to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ Specify all the JavaFX modules that your project uses:
     javafx {
         modules("javafx.controls", "javafx.fxml")
     }
+
+#### 2.1 Specify additional JVM arguments (Optional)
+
+Optionally, if you need some additional JVM arguments (for example to set --add-opens), you can specify them this way:
+
+**Groovy**
+
+    javafx {
+        additionalJvmArgs = [ '--add-opens=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED' ]
+    }
+
+**Kotlin**
+
+    javafx {
+        additionalJvmArgs("--add-opens=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED")
+    }
     
 ### 3. Specify JavaFX version
 

--- a/src/main/java/org/openjfx/gradle/JavaFXOptions.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXOptions.java
@@ -53,7 +53,7 @@ public class JavaFXOptions {
     private String configuration = "implementation";
     private String lastUpdatedConfiguration;
     private List<String> modules = new ArrayList<>();
-    private List<String> options = new ArrayList<>();
+    private List<String> additionalJvmArgs = new ArrayList<>();
     private FlatDirectoryArtifactRepository customSDKArtifactRepository;
 
     public JavaFXOptions(Project project) {
@@ -114,16 +114,16 @@ public class JavaFXOptions {
         setModules(List.of(moduleNames));
     }
 
-    public List<String> getOptions() {
-        return options;
+    public List<String> getAdditionalJvmArgs() {
+        return additionalJvmArgs;
     }
 
     /**
-     * A list of VM options passed to the executable
-     * @param options passed to the executable
+     * A list of additional JVM args passed to the executable
+     * @param additionalJvmArgs passed to the executable
      */
-    public void setOptions(List<String> options) {
-        this.options = options;
+    public void setAdditionalJvmArgs(List<String> additionalJvmArgs) {
+        this.additionalJvmArgs = additionalJvmArgs;
     }
 
 

--- a/src/main/java/org/openjfx/gradle/JavaFXOptions.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXOptions.java
@@ -53,6 +53,7 @@ public class JavaFXOptions {
     private String configuration = "implementation";
     private String lastUpdatedConfiguration;
     private List<String> modules = new ArrayList<>();
+    private List<String> options = new ArrayList<>();
     private FlatDirectoryArtifactRepository customSDKArtifactRepository;
 
     public JavaFXOptions(Project project) {
@@ -112,6 +113,19 @@ public class JavaFXOptions {
     public void modules(String...moduleNames) {
         setModules(List.of(moduleNames));
     }
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    /**
+     * A list of VM options passed to the executable
+     * @param options passed to the executable
+     */
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
 
     private void updateJavaFXDependencies() {
         clearJavaFXDependencies();

--- a/src/main/java/org/openjfx/gradle/tasks/ExecTask.java
+++ b/src/main/java/org/openjfx/gradle/tasks/ExecTask.java
@@ -86,7 +86,7 @@ public class ExecTask extends DefaultTask {
 
                     jvmArgs.add("--add-modules");
                     jvmArgs.add(String.join(",", definedJavaFXModuleNames));
-                    jvmArgs.addAll(javaFXOptions.getOptions());
+                    jvmArgs.addAll(javaFXOptions.getAdditionalJvmArgs());
 
                     List<String> execJvmArgs = execTask.getJvmArgs();
                     if (execJvmArgs != null) {

--- a/src/main/java/org/openjfx/gradle/tasks/ExecTask.java
+++ b/src/main/java/org/openjfx/gradle/tasks/ExecTask.java
@@ -86,6 +86,7 @@ public class ExecTask extends DefaultTask {
 
                     jvmArgs.add("--add-modules");
                     jvmArgs.add(String.join(",", definedJavaFXModuleNames));
+                    jvmArgs.addAll(javaFXOptions.getOptions());
 
                     List<String> execJvmArgs = execTask.getJvmArgs();
                     if (execJvmArgs != null) {


### PR DESCRIPTION
I have added vm options for executable to come closer to configuration options of javafx-maven-plugin. It's needed for example when --add-opens needs to be used.