### PR TITLE
use org.javamodularity:moduleplugin:1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation gradleApi()
 
     implementation 'com.google.gradle:osdetector-gradle-plugin:1.6.1'
-    implementation 'org.javamodularity:moduleplugin:1.6.0'
+    implementation 'org.javamodularity:moduleplugin:1.7.0'
 
     testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'


### PR DESCRIPTION
@tiainen @jperedadnr @abhinayagarwal Please publish a new release containing this PR. 

In version 1.7.0, the gradle-modules-plugin fixes several critical issues and is compatible with the newest versions of Gradle. 

The javafx-gradle-plugin version 0.0.8 still depends on gradle-modules-plugin 1.5.0, which is buggy and doesn't support Gradle 6.1 or newer.

A new release based on gradle-modules-plugin 1.7.0 will fix issues #59, #75, #76.