### PR TITLE
Add gradle wrapper validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Validate Gradle Wrapper
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # always run on pull requests
+
+jobs:
+  gradlevalidation:
+    name: "Validate Gradle Wrapper"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
There is a [gradle wrapper validation action](https://github.com/gradle/wrapper-validation-action#gradle-wrapper-validation-action) available. This PR enables it for this repo.

Reason: PRs https://github.com/openjfx/javafx-gradle-plugin/pull/79 and https://github.com/openjfx/javafx-gradle-plugin/pull/74 are touching the gradle binaries. Who knows whether non-good code was introduced there.