### PR TITLE
Make JavaFx platform configurable

### DIFF
--- a/src/main/java/org/openjfx/gradle/JavaFXOptions.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXOptions.java
@@ -46,7 +46,7 @@ public class JavaFXOptions {
     private static final String JAVAFX_SDK_LIB_FOLDER = "lib";
 
     private final Project project;
-    private final JavaFXPlatform platform;
+    private JavaFXPlatform platform;
 
     private String version = "13";
     private String sdk;
@@ -62,6 +62,11 @@ public class JavaFXOptions {
 
     public JavaFXPlatform getPlatform() {
         return platform;
+    }
+
+    public void setPlatform (final JavaFXPlatform platform){
+        this.platform = platform;
+        updateJavaFXDependencies();
     }
 
     public String getVersion() {


### PR DESCRIPTION
This PR Addresses https://github.com/openjfx/javafx-gradle-plugin/issues/99

Platform can now be configured as follows:

![image](https://user-images.githubusercontent.com/37125644/116840710-bb882e00-ab8b-11eb-9783-cd7635db48ed.png)

