### PR TITLE
Update moduleplugin to v1.8.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation gradleApi()
 
     implementation 'com.google.gradle:osdetector-gradle-plugin:1.6.1'
-    implementation 'org.javamodularity:moduleplugin:1.8.2'
+    implementation 'org.javamodularity:moduleplugin:1.8.8'
 
     testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation gradleApi()
 
     implementation 'com.google.gradle:osdetector-gradle-plugin:1.6.1'
-    implementation 'org.javamodularity:moduleplugin:1.8.8'
+    implementation 'org.javamodularity:moduleplugin:1.8.11'
 
     testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation gradleApi()
 
     implementation 'com.google.gradle:osdetector-gradle-plugin:1.6.1'
-    implementation 'org.javamodularity:moduleplugin:1.8.11'
+    implementation 'org.javamodularity:moduleplugin:1.8.10'
 
     testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'


### PR DESCRIPTION
updating module plugin, to fix issues with newer Gradle versions and Java17.
The issue is also described here: 
https://discuss.gradle.org/t/unable-to-build-project-with-gradle-7-3-1-on-java-17/41601
and here
https://github.com/java9-modularity/gradle-modules-plugin/issues/199
