### PR TITLE
Bump OsDetector plugin 1.6.1 -> 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     implementation gradleApi()
 
-    implementation 'com.google.gradle:osdetector-gradle-plugin:1.6.1'
+    implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
     implementation 'org.javamodularity:moduleplugin:1.8.10'
 
     testImplementation gradleTestKit()


### PR DESCRIPTION
Version 1.7.0 supports the Gradle Configuration Cache. The current version, 1.6.1, prevents the cache from being effective.