### PR TITLE
Create extra variable to force which platform should be used by JavaFX framework

### DIFF
--- a/src/main/java/org/openjfx/gradle/JavaFXOptions.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXOptions.java
@@ -46,7 +46,7 @@ public class JavaFXOptions {
     private static final String JAVAFX_SDK_LIB_FOLDER = "lib";
 
     private final Project project;
-    private final JavaFXPlatform platform;
+    private JavaFXPlatform platform;
 
     private String version = "16";
     private String sdk;
@@ -57,11 +57,15 @@ public class JavaFXOptions {
 
     public JavaFXOptions(Project project) {
         this.project = project;
-        this.platform = JavaFXPlatform.detect(project);
+        this.platform = JavaFXPlatform.detect(null, project);
     }
 
     public JavaFXPlatform getPlatform() {
         return platform;
+    }
+
+    public void setForcedPlatform(String forcedPlatform) {
+        this.platform = JavaFXPlatform.detect(forcedPlatform, project);
     }
 
     public String getVersion() {
@@ -70,7 +74,6 @@ public class JavaFXOptions {
 
     public void setVersion(String version) {
         this.version = version;
-        updateJavaFXDependencies();
     }
 
     /**
@@ -80,7 +83,6 @@ public class JavaFXOptions {
      */
     public void setSdk(String sdk) {
         this.sdk = sdk;
-        updateJavaFXDependencies();
     }
 
     public String getSdk() {
@@ -93,7 +95,6 @@ public class JavaFXOptions {
      */
     public void setConfiguration(String configuration) {
         this.configuration = configuration;
-        updateJavaFXDependencies();
     }
 
     public String getConfiguration() {
@@ -106,14 +107,13 @@ public class JavaFXOptions {
 
     public void setModules(List<String> modules) {
         this.modules = modules;
-        updateJavaFXDependencies();
     }
 
     public void modules(String...moduleNames) {
         setModules(List.of(moduleNames));
     }
 
-    private void updateJavaFXDependencies() {
+    public void updateJavaFXDependencies() {
         clearJavaFXDependencies();
 
         String configuration = getConfiguration();

--- a/src/main/java/org/openjfx/gradle/JavaFXPlatform.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXPlatform.java
@@ -56,9 +56,10 @@ public enum JavaFXPlatform {
         return classifier;
     }
 
-    public static JavaFXPlatform detect(Project project) {
+    public static JavaFXPlatform detect(String forcedPlatform, Project project) {
 
-        final String osClassifier = project.getExtensions().getByType(OsDetector.class).getClassifier();
+        final String osClassifier = (forcedPlatform!=null && !"".equals(forcedPlatform)) ? forcedPlatform : 
+            project.getExtensions().getByType(OsDetector.class).getClassifier();
 
         for ( JavaFXPlatform platform: values()) {
             if ( platform.osDetectorClassifier.equals(osClassifier)) {

--- a/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
@@ -45,5 +45,12 @@ public class JavaFXPlugin implements Plugin<Project> {
         project.getExtensions().create("javafx", JavaFXOptions.class, project);
 
         project.getTasks().create("configJavafxRun", ExecTask.class, project);
+
+        project.afterEvaluate(this::configureJavaLibs);
     }
+
+    private void configureJavaLibs(final Project project) {
+        project.getExtensions().configure(JavaFXOptions.class, javaFXOptions -> javaFXOptions.updateJavaFXDependencies());
+    }
+
 }


### PR DESCRIPTION
The extra parameter can be used similar to:

```
javafx {
    version = '12'
    modules = ['javafx.controls', 'javafx.base', 'javafx.graphics']
    forcedPlatform = 'windows-x86_64'
}

```

Which will force to use the Windows libraries for JavaFX. This will make it possible to cross-compile libraries for different operating systems.