### PR TITLE
Fixed Kotlin 1.7 not working because of gradle-modules-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation gradleApi()
 
     implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
-    implementation 'org.javamodularity:moduleplugin:1.8.10'
+    implementation 'org.javamodularity:moduleplugin:1.8.12'
 
     testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'


### PR DESCRIPTION
Bumped gradle-modules-plugin to version 1.8.12 because 1.8.12 fixes the Kotlin 1.7 issue.

The error you would get when using Kotlin 1.7:
```
> Cannot cast org.jetbrains.kotlin.gradle.tasks.KotlinCompile_Decorated to org.gradle.api.tasks.compile.AbstractCompile
```

It seems to work for me but please test it because I have never used this project before.

The kotlin 1.7 compatible version is available for testing on JitPack:
https://jitpack.io/#Nxllpointer/javafx-gradle-plugin-kotlin1_7-fix/9396882eea
To use the modified plugin put this in your settings.gradle:
```kotlin
pluginManagement {
    repositories {
        // ...
        gradlePluginPortal()
        maven(url = "https://jitpack.io/")
        // ...
    }
    resolutionStrategy {
        eachPlugin {
            when (requested.id.id) {
                "org.openjfx.javafxplugin" -> useModule("com.github.Nxllpointer.javafx-gradle-plugin-kotlin1_7-fix:javafx-gradle-plugin:9396882eea")
            }
        }
    }
}
// ...
```
