### PR TITLE
Update JavaFXPlugin to lazy-load and configure task

### DIFF
--- a/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXPlugin.java
@@ -44,6 +44,6 @@ public class JavaFXPlugin implements Plugin<Project> {
 
         project.getExtensions().create("javafx", JavaFXOptions.class, project);
 
-        project.getTasks().create("configJavafxRun", ExecTask.class, project);
+        project.getTasks().register("configJavafxRun", ExecTask.class, project);
     }
 }


### PR DESCRIPTION
Update JavaFXPlugin to lazy-load and configure task

## Motivation

When using the JavaFX Gradle plugin in conjunction with Gradle Enterprise, the build scan identified that this plugin was eagerly loading a task into the task graph when it did not need to. This slows down large builds with hundreds of modules and tasks. Since Gradle 5.0 the concept of [task configuration avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) was added. This helps speed up builds by only registering tasks when they are needed. This commit updates the JavaFX plugin to use task configuration avoidance.

## Modifications

Moving to task configuration avoidance is fairly straightforward. There is a guide in the [documentation](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html). The instance of the create() method was changed to the corresponding register() method.

## Result

The result is a Gradle plugin that leverages task configuration avoidance improving build times.