### PR TITLE
fetch git history to avoid new commit push failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
 
       - name: Setup Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
As a single commit is checked out and it is not present on the `master` branch, `git push` fails. The PR fetches history with 5 commits to enable a successful git push.