### PR TITLE
Migration notes from 0.0.14 to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,45 @@ providing you have signed the [Gluon Individual Contributor License Agreement (C
 
 ## Migrating from 0.0.14 to 0.1.0 ##
 
-Previously, on `0.0.14` and below there was an transitive dependency on `org.javamodularity.moduleplugin`.
-If your project stops working after updating to `0.1.0` or above, it's likely that you need to explicitly add
-the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin) back to your build to keep things working as they were.
-Note: There are other recommended alternatives over `org.javamodularity.moduleplugin` such as [extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info).
+Previously on `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
+If your **modular** project stops working after updating to `0.1.0` or above it is likely that you need to
+explicitly add the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin)
+back to your build and set `java.modularity.inferModulePath.set(false)` to keep things working as they were.
+
+Note: There are other recommended alternatives over `org.javamodularity.moduleplugin` for modular projects such as
+[extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info) that would allow you to keep
+`inferModulePath` set to **true** by declaring missing module information from legacy jars.
+
+**Groovy**
+
+````groovy
+plugins {
+    // ...
+    id 'org.openjfx.javafxplugin' version '0.1.0'
+    id 'org.javamodularity.moduleplugin' version '1.8.12'
+}
+
+// ...
+
+java {
+    // ...
+    modularity.inferModulePath.set(false)
+}
+````
+
+**Kotlin**
+
+````kotlin
+plugins {
+    // ...
+    id("org.openjfx.javafxplugin") version "0.1.0"
+    id("org.javamodularity.moduleplugin") version "1.8.12"
+}
+
+// ...
+
+java {
+    // ...
+    modularity.inferModulePath.set(false)
+}
+````

--- a/README.md
+++ b/README.md
@@ -208,28 +208,29 @@ providing you have signed the [Gluon Individual Contributor License Agreement (C
 
 ## Migrating from 0.0.14 to 0.1.0
 
-Version `0.1.0` had a couple number of changes and improvements such as lazy dependency declaration,
-variant-aware dependency management, and support for Gradle's built-in JPMS functionality. In addition,
-the previous version used to rewrite the classpath/module path. This is no longer the case to minimize
-making changes to your build and as a result your past builds may be potentially affected when you upgrade
-the plugin. On the next section there's a couple of troubleshooting steps that may help with the transition
-if you encounter issues when upgrading. These examples are provided in a best-effort basis, but feel free to
-open an issue if you think there's a migration scenario that's not captured here that should be included.
+Version `0.1.0` introduced several changes and improvements, including lazy dependency declaration,
+variant-aware dependency management, and support for Gradle's built-in JPMS functionality. In the
+previous version, the classpath/module path was rewritten. This is no longer the case. As a result,
+your past builds might be affected when you upgrade the plugin. In the next section, there are a few
+troubleshooting steps that might help with the transition if you encounter issues when upgrading.
+These examples are provided on a best-effort basis, but feel free to open an issue if you believe
+there's a migration scenario not covered here that should be included.
 
 ### Troubleshooting
 
 #### Gradle version
 
-The plugin now requires Gradle 6.1 and above. Consider updating your Gradle settings, wrapper, and build to
-a more modern Gradle version along with plugins and dependencies to minimize issues with the plugin.
+The plugin now requires `Gradle 6.1` or higher. Consider updating your Gradle settings, wrapper,
+and build to a more recent version of Gradle. Additionally, updating your plugins and dependencies
+can help minimize issues with the plugin.
 
 #### Mixed JavaFX jars
 
-If you see mixed JavaFX jars (e.g. `javafx-base-x.y.z-linux.jar`, `java-base-x.y.z-mac.jar`) during `build`, `test`,
-`assemble` or other tasks or see errors like `Error initializing QuantumRenderer: no suitable pipeline found` it
-is likely one or more of your dependencies may have published metadata that includes JavaFX dependencies with
-classifiers. The ideal solution is to reach out to library authors to update their JavaFX plugin and publish a
-patch with fixed metadata. A fallback solution to this is to `exclude group: 'org.openjfx'` on the dependencies
+If you encounter mixed classified JavaFX jars or see errors like `Error initializing QuantumRenderer: no
+suitable pipeline found` during executing task like `build`, `test`, `assemble`, etc., it is likely one
+or more of your dependencies have published metadata that includes JavaFX dependencies with classifiers.
+The ideal solution is to reach out to library authors to update their JavaFX plugin and publish a patch
+with fixed metadata. A fallback solution to this is to `exclude group: 'org.openjfx'` on the dependencies
 causing the issue.
 
 ```groovy
@@ -240,11 +241,11 @@ implementation('com.example.fx:foo:1.0.0') {
 
 #### Variants
 
-If you see errors such as `Cannot choose between the following variants of org.openjfx...` it is possible that
-your build or another plugin is interacting with the classpath/module path in a way that "breaks" functionality
-provided by this plugin. In such cases, you may need to re-declare the variants yourself as described in
-[Gradle docs on attribute matching/variants](https://docs.gradle.org/current/userguide/variant_attributes.html)
-or reach out to the plugin author in an attempt to remediate the situation.
+If you encounter errors such as `Cannot choose between the following variants of org.openjfx...` it is possible
+that your build or another plugin is interacting with the classpath/module path in a way that "breaks" functionality
+provided by this plugin. In such cases, you may need to re-declare the variants yourself as described in [Gradle docs
+on attribute matching/variants](https://docs.gradle.org/current/userguide/variant_attributes.html) or reach out to
+the plugin author in an attempt to remediate the situation.
 
 ```groovy
 // Approach 1: Explicit Variant
@@ -268,8 +269,8 @@ configurations.someConfiguration  {
 
 #### Extra plugins
 
-On `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
-If your **modular** project stops working after updating to `0.1.0` or above it is likely that you need to
+In versions `0.0.14` and below, there was a transitive dependency on `org.javamodularity.moduleplugin`.
+If your **modular** project stops working after updating to `0.1.0` or above, it is likely that you need to
 explicitly add the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin)
 back to your build and set `java.modularity.inferModulePath.set(false)` to keep things working as they were.
 This plugin helped with transitive dependencies on legacy jars that haven't been modularized yet, but now you

--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ javafx {
 }
 </code></pre>
     
-## Issues and Contributions ##
+## Issues and Contributions
 
 Issues can be reported to the [Issue tracker](https://github.com/openjfx/javafx-gradle-plugin/issues/).
 
 Contributions can be submitted via [Pull requests](https://github.com/openjfx/javafx-gradle-plugin/pulls/), 
 providing you have signed the [Gluon Individual Contributor License Agreement (CLA)](https://cla.gluonhq.com/).
 
-## Migrating from 0.0.14 to 0.1.0 ##
+## Migrating from 0.0.14 to 0.1.0
 
 Previously on `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
 If your **modular** project stops working after updating to `0.1.0` or above it is likely that you need to

--- a/README.md
+++ b/README.md
@@ -262,11 +262,6 @@ explicitly add the [org.javamodularity.moduleplugin](https://plugins.gradle.org/
 back to your build and set `java.modularity.inferModulePath.set(false)` to keep things working as they were.
 This change should not be required for non-modular projects.
 
-**Note**: There are other recommended alternatives over `org.javamodularity.moduleplugin` for modular projects such as
-[extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info) that would allow you to keep
-`inferModulePath` set to **true** by declaring missing module information from legacy jars. More details on how to
-accomplish can be found on the plugin's source code repository.
-
 **Before**
 
 ````groovy
@@ -287,3 +282,8 @@ java {
     modularity.inferModulePath.set(false)
 }
 ````
+
+**Note**: There are other recommended alternatives over `org.javamodularity.moduleplugin` for modular projects such as
+[extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info) that would allow you to keep
+`inferModulePath` set to **true** by declaring missing module information from legacy jars. More details on how to
+accomplish can be found on the plugin's source code repository.

--- a/README.md
+++ b/README.md
@@ -208,14 +208,25 @@ providing you have signed the [Gluon Individual Contributor License Agreement (C
 
 ## Migrating from 0.0.14 to 0.1.0
 
-The previous version rewrote the whole classpath/module path and removed the "wrong" transitive Jars. This is no
-longer the case. As a result, there's a couple possible situations that may occur that are described below.
+Version `0.1.0` had a couple number of changes and improvements such as lazy dependency declaration,
+variant-aware dependency management, and support for Gradle's built-in JPMS functionality. In addition,
+the previous version used to rewrite the classpath/module path. This is no longer the case to minimize
+making changes to your build and as a result your past builds may be potentially affected when you upgrade
+the plugin. On the next section there's a couple of troubleshooting steps that may help with the transition
+if you encounter issues when upgrading. These examples are provided in a best-effort basis, but feel free to
+open an issue if you think there's a migration scenario that's not captured here that should be included.
 
-If you have problems with mixed JavaFX jars (e.g. `javafx-base-linux`, `java-base-mac`) during `assemble` task
-or see errors like `Error initializing QuantumRenderer: no suitable pipeline found` it is likely one or more
+### Troubleshooting
+
+#### Mixed JavaFX jars
+
+If you see mixed JavaFX jars (e.g. `javafx-base-x.y.z-linux.jar`, `java-base-x.y.z-mac.jar`) during `assemble`
+task or see errors like `Error initializing QuantumRenderer: no suitable pipeline found` it is likely one or more
 of your dependencies may have published metadata that includes JavaFX dependencies with classifiers. The ideal
 solution is to reach out to library authors to update their JavaFX plugin and publish a patch with fixed metadata.
 A fallback solution to this is to `exclude group: 'org.openjfx'` on the dependencies causing the issue.
+
+#### Variants
 
 If you see errors such as `Cannot choose between the following variants of org.openjfx...` it is possible that
 your build or another plugin is interacting with the classpath/module path in a way that "breaks" functionality
@@ -243,46 +254,36 @@ configurations.xjcCatalogResolution  {
 }
 ```
 
-Additionally on `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
+#### Extra plugins
+
+On `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
 If your **modular** project stops working after updating to `0.1.0` or above it is likely that you need to
 explicitly add the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin)
 back to your build and set `java.modularity.inferModulePath.set(false)` to keep things working as they were.
-This change is not required for non-modular projects.
+This change should not be required for non-modular projects.
 
-Note: There are other recommended alternatives over `org.javamodularity.moduleplugin` for modular projects such as
+**Note**: There are other recommended alternatives over `org.javamodularity.moduleplugin` for modular projects such as
 [extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info) that would allow you to keep
-`inferModulePath` set to **true** by declaring missing module information from legacy jars.
+`inferModulePath` set to **true** by declaring missing module information from legacy jars. More details on how to
+accomplish can be found on the plugin's source code repository.
 
-**Groovy**
+**Before**
 
 ````groovy
 plugins {
-    // ...
+    id 'org.openjfx.javafxplugin' version '0.0.14'
+}
+````
+
+**After**
+
+````groovy
+plugins {
     id 'org.openjfx.javafxplugin' version '0.1.0'
     id 'org.javamodularity.moduleplugin' version '1.8.12'
 }
 
-// ...
-
 java {
-    // ...
-    modularity.inferModulePath.set(false)
-}
-````
-
-**Kotlin**
-
-````kotlin
-plugins {
-    // ...
-    id("org.openjfx.javafxplugin") version "0.1.0"
-    id("org.javamodularity.moduleplugin") version "1.8.12"
-}
-
-// ...
-
-java {
-    // ...
     modularity.inferModulePath.set(false)
 }
 ````

--- a/README.md
+++ b/README.md
@@ -301,3 +301,29 @@ java {
 [extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info) that would allow you to keep
 `inferModulePath` set to **true** by declaring missing module information from legacy jars. More details on how to
 accomplish can be found on the plugin's source code repository.
+
+#### Dependency hierarchy
+
+Version `1.0.0` now relies on JavaFX modules defining their transitive modules rather than flattening them.
+This change allows you to publish metadata declaring only the JavaFX modules you need, meaning it does not
+include transitive JavaFX modules as part of your published metadata.
+
+Some plugins rely on having all modules (transitive included) declared as "top-level" modules such as the
+`badass-runtime-plugin` on **non-modular** projects. In this particular case, it is necessary to declare
+all modules to restore previous functionality from `0.0.14` and below.
+
+**Before**
+
+````groovy
+javafx {
+    modules = ['javafx.controls']
+}
+````
+
+**After**
+
+````groovy
+javafx {
+    modules = ['javafx.base', 'javafx.graphics', 'javafx.controls']
+}
+````

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ accomplish can be found on the plugin's source code repository.
 
 #### Dependency hierarchy
 
-Version `1.0.0` now relies on JavaFX modules defining their transitive modules rather than flattening them.
+Version `0.1.0` now relies on JavaFX modules defining their transitive modules rather than flattening them.
 This change allows you to publish metadata declaring only the JavaFX modules you need, meaning it does not
 include transitive JavaFX modules as part of your published metadata.
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,14 @@ providing you have signed the [Gluon Individual Contributor License Agreement (C
 
 ## Migrating from 0.0.14 to 0.1.0
 
-Previously on `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
+The previous version rewrote the whole classpath/module path and removed the "wrong" transitive Jars. This is no
+longer the case. If you have problems with mixed JavaFX jars (e.g. `javafx-base-linux`, `java-base-mac`) during
+`assemble` task or see errors like `Error initializing QuantumRenderer: no suitable pipeline found` it is likely
+one or more of your dependencies may have published metadata that includes JavaFX dependencies with classifiers.
+The ideal solution is to reach out to library authors to update their JavaFX plugin and publish a patch with fixed
+metadata. A fallback solution to this is to `exclude group: 'org.openjfx'` on the dependencies causing the issue.
+
+Additionally on `0.0.14` and below there was a transitive dependency on `org.javamodularity.moduleplugin`.
 If your **modular** project stops working after updating to `0.1.0` or above it is likely that you need to
 explicitly add the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin)
 back to your build and set `java.modularity.inferModulePath.set(false)` to keep things working as they were.

--- a/README.md
+++ b/README.md
@@ -205,3 +205,10 @@ Issues can be reported to the [Issue tracker](https://github.com/openjfx/javafx-
 
 Contributions can be submitted via [Pull requests](https://github.com/openjfx/javafx-gradle-plugin/pulls/), 
 providing you have signed the [Gluon Individual Contributor License Agreement (CLA)](https://cla.gluonhq.com/).
+
+## Migrating from 0.0.14 to 0.1.0 ##
+
+Previously, on `0.0.14` and below there was an transitive dependency on `org.javamodularity.moduleplugin`.
+If your project stops working after updating to `0.1.0` or above, it's likely that you need to explicitly add
+the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin) back to your build to keep things working as they were.
+Note: There are other recommended alternatives over `org.javamodularity.moduleplugin` such as [extra-java-module-info](https://github.com/gradlex-org/extra-java-module-info).


### PR DESCRIPTION
After https://github.com/openjfx/javafx-gradle-plugin/pull/151 got merged, I think adding these migration notes is worthwhile as it's easy to encounter the [org.javamodularity.moduleplugin](https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin) missing plugin issue on other larger projects.

