### PR TITLE
Support Monocle builds

### DIFF
--- a/src/main/java/org/openjfx/gradle/JavaFXPlatform.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXPlatform.java
@@ -61,6 +61,10 @@ public enum JavaFXPlatform {
         return classifier;
     }
 
+    public String getJarClassifier() {
+        return classifier + (isHeadless() ? "-monocle" : "");
+    }
+
     public String getOsFamily() {
         return osFamily;
     }
@@ -110,5 +114,9 @@ public enum JavaFXPlatform {
                 return JavaFXPlatform.OSX_AARCH64;
         }
         return valueOf(platform);
+    }
+
+    private static boolean isHeadless() {
+        return "true".equals(System.getProperty("java.awt.headless"));
     }
 }

--- a/src/main/java/org/openjfx/gradle/metadatarule/JavaFXComponentMetadataRule.java
+++ b/src/main/java/org/openjfx/gradle/metadatarule/JavaFXComponentMetadataRule.java
@@ -79,7 +79,7 @@ abstract public class JavaFXComponentMetadataRule implements ComponentMetadataRu
             });
             variant.withFiles(files -> {
                 files.removeAllFiles();
-                files.addFile(name + "-" + version + "-" + javaFXPlatform.getClassifier() + ".jar");
+                files.addFile(name + "-" + version + "-" + javaFXPlatform.getJarClassifier() + ".jar");
             });
         });
     }


### PR DESCRIPTION
This PR adds support for building JavaFX apps using [Monocle](https://wiki.openjdk.org/display/OpenJFX/Monocle), by detecting the system property `java.awt.headless`.

A monocle build can thus be made using (for example):
```
./gradlew -Djava.awt.headless=true run
```