### PR TITLE
Support adding incubator modules via the Gradle plugin

### DIFF
--- a/src/main/java/org/openjfx/gradle/JavaFXModule.java
+++ b/src/main/java/org/openjfx/gradle/JavaFXModule.java
@@ -48,15 +48,26 @@ public enum JavaFXModule {
     FXML(BASE, GRAPHICS),
     MEDIA(BASE, GRAPHICS),
     SWING(BASE, GRAPHICS),
-    WEB(BASE, CONTROLS, GRAPHICS, MEDIA);
+    WEB(BASE, CONTROLS, GRAPHICS, MEDIA),
+    INPUT_INCUBATOR(true, BASE, GRAPHICS, CONTROLS),
+    RICHTEXT_INCUBATOR(true, BASE, GRAPHICS, CONTROLS, INPUT_INCUBATOR),
+    ;
 
     static final String PREFIX_MODULE = "javafx.";
+    static final String INCUBATOR_PREFIX_MODULE = "jfx.incubator.";
     private static final String PREFIX_ARTIFACT = "javafx-";
+    private static final String INCUBATOR_PREFIX_ARTIFACT = "jfx-incubator-";
 
     private final List<JavaFXModule> dependentModules;
+    private final boolean isIncubator;
+
+    JavaFXModule(boolean isIncubator, JavaFXModule... dependentModules) {
+        this.isIncubator = isIncubator;
+        this.dependentModules = List.of(dependentModules);
+    }
 
     JavaFXModule(JavaFXModule...dependentModules) {
-        this.dependentModules = List.of(dependentModules);
+        this(false, dependentModules);
     }
 
     public static Optional<JavaFXModule> fromModuleName(String moduleName) {
@@ -65,8 +76,12 @@ public enum JavaFXModule {
                 .findFirst();
     }
 
+    private String baseName() {
+        return name().replace("_INCUBATOR", "").toLowerCase(Locale.ROOT);
+    }
+
     public String getModuleName() {
-        return PREFIX_MODULE + name().toLowerCase(Locale.ROOT);
+        return (isIncubator ? INCUBATOR_PREFIX_MODULE : PREFIX_MODULE) + baseName();
     }
 
     public String getModuleJarFileName() {
@@ -74,7 +89,7 @@ public enum JavaFXModule {
     }
 
     public String getArtifactName() {
-        return PREFIX_ARTIFACT + name().toLowerCase(Locale.ROOT);
+        return (isIncubator ? INCUBATOR_PREFIX_ARTIFACT : PREFIX_ARTIFACT) + baseName();
     }
 
     public boolean compareJarFileName(JavaFXPlatform platform, String jarFileName) {

--- a/src/test/java/org/openjfx/gradle/JavaFXModuleTest.java
+++ b/src/test/java/org/openjfx/gradle/JavaFXModuleTest.java
@@ -64,6 +64,28 @@ class JavaFXModuleTest {
     }
 
     @Test
+    void existingIncubatorModuleName() {
+        Optional<JavaFXModule> javafxDependency = JavaFXModule.fromModuleName("jfx.incubator.richtext");
+        assertTrue(javafxDependency.isPresent(), "Expected the text to convert to a module, but it did not");
+        assertEquals(JavaFXModule.RICHTEXT_INCUBATOR, javafxDependency.get());
+    }
+
+    @Test
+    void nonExistingIncubatorModuleName() {
+        assertTrue(JavaFXModule.fromModuleName("jfx.incubator.unknown").isEmpty(), "Somehow got a module from an unknown module name.");
+    }
+
+    @Test
+    void getIncubatorModuleName() {
+        assertEquals("jfx.incubator.richtext", JavaFXModule.RICHTEXT_INCUBATOR.getModuleName());
+    }
+
+    @Test
+    void getIncubatorArtifactName() {
+        assertEquals("jfx-incubator-richtext", JavaFXModule.RICHTEXT_INCUBATOR.getArtifactName());
+    }
+
+    @Test
     void validateWithValidModules() {
         var moduleNames = List.of(JavaFXModule.CONTROLS.getModuleName(), JavaFXModule.WEB.getModuleName());
 


### PR DESCRIPTION
Fixes #177 

I don't love this approach but there are some constraints:
1. Because the plugin is independent of the JavaFX version, I expect that JavaFX will potentially incubate other modules that become top-level modules. So the enum namespace had to incorporate potentially both incubator and non-incubator modules. Hence the `_INCUBATOR` name. However, this exceeds the bounds of what's known, so perhaps this is not specifically necessary.
2. That said, keying off a name (e.g., asserting that all incubator modules have `_INCUBATOR` attached) is not ideal. That's why there's an explicit boolean, default `false`, that also indicates that it's an incubator.

Other approaches considered:
* Not doing this at all, but as explained in #177, using incubator modules becomes challenging.
* As in point 2 above, dropping the boolean and keying off the name
* Simply hardcoding the incubator module and artifact names instead of calculating them (in fact, we should consider just doing that for all these items).
* Switching the enums to lower-case in order to avoid a locale-sensitive operation like changing the case of `I`.
* Dropping the enum entirely and building a `Map<String, JavaFXModule>` where the key is the module name and the record contains all the necessary data fields. I didn't think that was level of rewrite was necessarily beneficial, and it would raise the minimum Java version of the plugin from 11 to 16.